### PR TITLE
Validate infix expressions

### DIFF
--- a/src/structs/infix_expression.rs
+++ b/src/structs/infix_expression.rs
@@ -8,11 +8,7 @@ pub struct InfixExpression<Predicate> {
 impl<Predicate> InfixExpression<Predicate> {
     #[must_use]
     pub fn from_tokens(tokens: Vec<InfixToken<Predicate>>) -> Option<Self> {
-        if Self::are_tokens_valid(&tokens) {
-            Some(Self { tokens })
-        } else {
-            None
-        }
+        Self::are_tokens_valid(&tokens).then(|| Self { tokens })
     }
 
     #[must_use]

--- a/src/structs/infix_expression.rs
+++ b/src/structs/infix_expression.rs
@@ -16,7 +16,7 @@ impl<Predicate> InfixExpression<Predicate> {
     }
 
     #[must_use]
-    pub fn to_postfix(self) -> Option<PostfixExpression<Predicate>> {
+    pub fn to_postfix(self) -> PostfixExpression<Predicate> {
         let mut stack: Vec<InfixStackItem> = Vec::new();
         let mut output_queue: Vec<PostfixToken<Predicate>> = Vec::new();
 
@@ -44,9 +44,7 @@ impl<Predicate> InfixExpression<Predicate> {
                         output_queue.push(PostfixToken::Operator(*op));
                         stack.pop();
                     }
-                    if stack.last() != Some(&InfixStackItem::Parenthesis(Parenthesis::Open)) {
-                        return None;
-                    }
+                    // pop the open parenthesis
                     stack.pop();
                 }
             }
@@ -56,11 +54,7 @@ impl<Predicate> InfixExpression<Predicate> {
             output_queue.push(PostfixToken::Operator(op));
         }
 
-        if !stack.is_empty() {
-            return None;
-        }
-
-        Some(PostfixExpression::from_tokens(output_queue))
+        PostfixExpression::from_tokens(output_queue)
     }
 
     fn are_tokens_valid(tokens: &[InfixToken<Predicate>]) -> bool {

--- a/src/structs/postfix_expression.rs
+++ b/src/structs/postfix_expression.rs
@@ -49,4 +49,9 @@ impl<Predicate> PostfixExpression<Predicate> {
         }
         Some(stack.pop()?.evaluate(evaluator))
     }
+
+    fn are_tokens_valid(tokens: &[PostfixToken<Predicate>]) -> bool {
+        // TODO: verify that the expression is valid
+        unimplemented!();
+    }
 }

--- a/tests/infix.rs
+++ b/tests/infix.rs
@@ -16,7 +16,7 @@ fn test_infix_to_postfix_parenthesis() {
     ])
     .unwrap();
 
-    let postfix = infix.to_postfix().unwrap();
+    let postfix = infix.to_postfix();
     assert_eq!(
         postfix,
         PostfixExpression::from_tokens(vec![
@@ -41,7 +41,7 @@ fn test_infix_to_postfix_plain() {
     ])
     .unwrap();
 
-    let postfix = infix.to_postfix().unwrap();
+    let postfix = infix.to_postfix();
     assert_eq!(
         postfix,
         PostfixExpression::from_tokens(vec![
@@ -59,7 +59,7 @@ fn test_infix_to_postfix_plain() {
 fn test_infix_to_postfix_single() {
     let infix = InfixExpression::from_tokens(vec![InfixToken::Predicate("a")]).unwrap();
 
-    let postfix = infix.to_postfix().unwrap();
+    let postfix = infix.to_postfix();
     assert_eq!(
         postfix,
         PostfixExpression::from_tokens(vec![PostfixToken::Predicate("a"),])
@@ -73,9 +73,10 @@ fn test_infix_to_postfix_single_with_parenthesis() {
         InfixToken::Parenthesis(Parenthesis::Open),
         InfixToken::Predicate("a"),
         InfixToken::Parenthesis(Parenthesis::Close),
-    ]).unwrap();
+    ])
+    .unwrap();
 
-    let postfix = infix.to_postfix().unwrap();
+    let postfix = infix.to_postfix();
     assert_eq!(
         postfix,
         PostfixExpression::from_tokens(vec![PostfixToken::Predicate("a"),])
@@ -91,9 +92,10 @@ fn test_infix_to_postfix_simple_with_parenthesis() {
         InfixToken::Operator(Operator::Or),
         InfixToken::Predicate("b"),
         InfixToken::Parenthesis(Parenthesis::Close),
-    ]).unwrap();
+    ])
+    .unwrap();
 
-    let postfix = infix.to_postfix().unwrap();
+    let postfix = infix.to_postfix();
     assert_eq!(
         postfix,
         PostfixExpression::from_tokens(vec![
@@ -120,7 +122,7 @@ fn test_infix_to_postfix_and_or() {
         ])
         .unwrap();
 
-        let postfix = infix.to_postfix().unwrap();
+        let postfix = infix.to_postfix();
         assert_eq!(
             postfix,
             PostfixExpression::from_tokens(vec![
@@ -170,7 +172,7 @@ fn test_infix_to_postfix_complex() {
     ])
     .unwrap();
 
-    let postfix = infix.to_postfix().unwrap();
+    let postfix = infix.to_postfix();
     assert_eq!(
         postfix,
         PostfixExpression::from_tokens(vec![
@@ -332,10 +334,8 @@ fn test_infix_invalid_using_postfix() {
 #[test]
 // ab [invalid]
 fn test_infix_invalid_only_predicates() {
-    let infix = InfixExpression::from_tokens(vec![
-        InfixToken::Predicate("a"),
-        InfixToken::Predicate("b"),
-    ]);
+    let infix =
+        InfixExpression::from_tokens(vec![InfixToken::Predicate("a"), InfixToken::Predicate("b")]);
     assert!(infix.is_none());
 }
 

--- a/tests/infix.rs
+++ b/tests/infix.rs
@@ -116,7 +116,7 @@ fn test_infix_to_postfix_simple_with_more_parenthesis() {
         InfixToken::Predicate("b"),
         InfixToken::Parenthesis(Parenthesis::Close),
     ])
-        .unwrap();
+    .unwrap();
 
     let postfix = infix.to_postfix();
     assert_eq!(

--- a/tests/infix.rs
+++ b/tests/infix.rs
@@ -107,6 +107,29 @@ fn test_infix_to_postfix_simple_with_parenthesis() {
 }
 
 #[test]
+// ((a)+(b)) --> ab+
+fn test_infix_to_postfix_simple_with_more_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("b"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ])
+        .unwrap();
+
+    let postfix = infix.to_postfix();
+    assert_eq!(
+        postfix,
+        PostfixExpression::from_tokens(vec![
+            PostfixToken::Predicate("a"),
+            PostfixToken::Predicate("b"),
+            PostfixToken::Operator(Operator::Or),
+        ])
+    );
+}
+
+#[test]
 // a*b*c*d --> ab*c*d*
 // a+b+c+d --> ab+c+d+
 fn test_infix_to_postfix_and_or() {

--- a/tests/infix.rs
+++ b/tests/infix.rs
@@ -13,7 +13,8 @@ fn test_infix_to_postfix_parenthesis() {
         InfixToken::Operator(Operator::Or),
         InfixToken::Predicate("c"),
         InfixToken::Parenthesis(Parenthesis::Close),
-    ]);
+    ])
+    .unwrap();
 
     let postfix = infix.to_postfix().unwrap();
     assert_eq!(
@@ -37,7 +38,8 @@ fn test_infix_to_postfix_plain() {
         InfixToken::Predicate("b"),
         InfixToken::Operator(Operator::Or),
         InfixToken::Predicate("c"),
-    ]);
+    ])
+    .unwrap();
 
     let postfix = infix.to_postfix().unwrap();
     assert_eq!(
@@ -55,12 +57,50 @@ fn test_infix_to_postfix_plain() {
 #[test]
 // a --> a
 fn test_infix_to_postfix_single() {
-    let infix = InfixExpression::from_tokens(vec![InfixToken::Predicate("a")]);
+    let infix = InfixExpression::from_tokens(vec![InfixToken::Predicate("a")]).unwrap();
 
     let postfix = infix.to_postfix().unwrap();
     assert_eq!(
         postfix,
         PostfixExpression::from_tokens(vec![PostfixToken::Predicate("a"),])
+    );
+}
+
+#[test]
+// (a) --> a
+fn test_infix_to_postfix_single_with_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("a"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]).unwrap();
+
+    let postfix = infix.to_postfix().unwrap();
+    assert_eq!(
+        postfix,
+        PostfixExpression::from_tokens(vec![PostfixToken::Predicate("a"),])
+    );
+}
+
+#[test]
+// (a+b) --> ab+
+fn test_infix_to_postfix_simple_with_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("b"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]).unwrap();
+
+    let postfix = infix.to_postfix().unwrap();
+    assert_eq!(
+        postfix,
+        PostfixExpression::from_tokens(vec![
+            PostfixToken::Predicate("a"),
+            PostfixToken::Predicate("b"),
+            PostfixToken::Operator(Operator::Or),
+        ])
     );
 }
 
@@ -77,7 +117,8 @@ fn test_infix_to_postfix_and_or() {
             InfixToken::Predicate("c"),
             InfixToken::Operator(op),
             InfixToken::Predicate("d"),
-        ]);
+        ])
+        .unwrap();
 
         let postfix = infix.to_postfix().unwrap();
         assert_eq!(
@@ -96,9 +137,11 @@ fn test_infix_to_postfix_and_or() {
 }
 
 #[test]
-// a*(b+c+d*(e+f)+g)+h+i*j --> abc+def+*+g+*h+ij*+
+// ((a*(b+c+d*(e+f)+g)+h+i*j)) --> abc+def+*+g+*h+ij*+
 fn test_infix_to_postfix_complex() {
     let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Parenthesis(Parenthesis::Open),
         InfixToken::Predicate("a"),
         InfixToken::Operator(Operator::And),
         InfixToken::Parenthesis(Parenthesis::Open),
@@ -122,7 +165,10 @@ fn test_infix_to_postfix_complex() {
         InfixToken::Predicate("i"),
         InfixToken::Operator(Operator::And),
         InfixToken::Predicate("j"),
-    ]);
+        InfixToken::Parenthesis(Parenthesis::Close),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ])
+    .unwrap();
 
     let postfix = infix.to_postfix().unwrap();
     assert_eq!(
@@ -149,4 +195,275 @@ fn test_infix_to_postfix_complex() {
             PostfixToken::Operator(Operator::Or),
         ])
     );
+}
+
+#[test]
+// a*+b [invalid]
+fn test_infix_invalid_consecutive_operators() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::And),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("b"),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// + [invalid]
+// * [invalid]
+fn test_infix_invalid_only_one_operator() {
+    for op in [Operator::And, Operator::Or] {
+        let infix = InfixExpression::<u8>::from_tokens(vec![InfixToken::Operator(op)]);
+        assert!(infix.is_none());
+    }
+}
+
+#[test]
+// +*+ [invalid]
+fn test_infix_invalid_only_operators() {
+    let infix = InfixExpression::<u8>::from_tokens(vec![
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Operator(Operator::And),
+        InfixToken::Operator(Operator::Or),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// ( [invalid]
+// ) [invalid]
+fn test_infix_invalid_only_one_parenthesis() {
+    for paren in [Parenthesis::Open, Parenthesis::Close] {
+        let infix = InfixExpression::<u8>::from_tokens(vec![InfixToken::Parenthesis(paren)]);
+        assert!(infix.is_none());
+    }
+}
+
+#[test]
+// () [invalid]
+fn test_infix_invalid_only_parenthesis() {
+    let infix = InfixExpression::<u8>::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// +a [invalid]
+fn test_infix_invalid_starts_with_operator() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("a"),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// (+a) [invalid]
+fn test_infix_invalid_starts_with_parenthesis_and_operator() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("a"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// a+ [invalid]
+fn test_infix_invalid_ends_with_operator() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::Or),
+    ]);
+    assert!(infix.is_none());
+}
+#[test]
+
+// (a+) [invalid]
+fn test_infix_invalid_ends_with_operator_and_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// ab+ [invalid]
+fn test_infix_invalid_consecutive_predicates_and_operator() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Predicate("b"),
+        InfixToken::Operator(Operator::Or),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// +ab [invalid]
+fn test_infix_invalid_operator_and_consecutive_predicates() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("a"),
+        InfixToken::Predicate("b"),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// ab*c+ [invalid]
+fn test_infix_invalid_using_postfix() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Predicate("b"),
+        InfixToken::Operator(Operator::And),
+        InfixToken::Predicate("c"),
+        InfixToken::Operator(Operator::Or),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// ab [invalid]
+fn test_infix_invalid_only_predicates() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Predicate("b"),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// )a+b( [invalid]
+fn test_infix_invalid_swapped_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Close),
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("b"),
+        InfixToken::Parenthesis(Parenthesis::Open),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// (a+b [invalid]
+fn test_infix_invalid_missing_close_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("b"),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// a+b) [invalid]
+fn test_infix_invalid_missing_open_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("b"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// (a*(b+c) [invalid]
+fn test_infix_invalid_more_open_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::And),
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("b"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("c"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// a*(b+c)) [invalid]
+fn test_infix_invalid_more_close_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::And),
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("b"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("c"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// a(b+c) [invalid]
+fn test_infix_invalid_missing_operator_before_open_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("b"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("c"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// a*(+b+c) [invalid]
+fn test_infix_invalid_operator_after_open_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::And),
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("b"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("c"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// a*(b+c)d [invalid]
+fn test_infix_invalid_predicate_after_close_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::And),
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("b"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Predicate("c"),
+        InfixToken::Parenthesis(Parenthesis::Close),
+        InfixToken::Predicate("d"),
+    ]);
+    assert!(infix.is_none());
+}
+
+#[test]
+// a*(b+) [invalid]
+fn test_infix_invalid_missing_predicate_before_close_parenthesis() {
+    let infix = InfixExpression::from_tokens(vec![
+        InfixToken::Predicate("a"),
+        InfixToken::Operator(Operator::And),
+        InfixToken::Parenthesis(Parenthesis::Open),
+        InfixToken::Predicate("b"),
+        InfixToken::Operator(Operator::Or),
+        InfixToken::Parenthesis(Parenthesis::Close),
+    ]);
+    assert!(infix.is_none());
 }


### PR DESCRIPTION
Ensure that objects of type `InfixExpression` are always valid.