### PR TITLE
Validate postfix expressions

### DIFF
--- a/src/structs/infix_expression.rs
+++ b/src/structs/infix_expression.rs
@@ -55,16 +55,16 @@ impl<Predicate> InfixExpression<Predicate> {
 
     fn are_tokens_valid(tokens: &[InfixToken<Predicate>]) -> bool {
         let mut operator_stack: Vec<InfixStackItem> = Vec::new();
-        let mut predicate_stack: Vec<&Predicate> = Vec::new();
+        let mut predicate_cnt: usize = 0;
         let mut predicate_expected = true;
 
         for token in tokens {
             match token {
-                InfixToken::Predicate(p) => {
+                InfixToken::Predicate(_) => {
                     if !predicate_expected {
                         return false;
                     }
-                    predicate_stack.push(p);
+                    predicate_cnt += 1;
                     predicate_expected = false;
                 }
                 InfixToken::Operator(op) => {
@@ -77,10 +77,10 @@ impl<Predicate> InfixExpression<Predicate> {
                 InfixToken::Parenthesis(Parenthesis::Close) => {
                     while let Some(InfixStackItem::Operator(_)) = operator_stack.last() {
                         operator_stack.pop();
-                        if predicate_stack.len() < 2 {
+                        if predicate_cnt < 2 {
                             return false;
                         }
-                        predicate_stack.pop();
+                        predicate_cnt -= 1;
                     }
                     if operator_stack.last()
                         != Some(&InfixStackItem::Parenthesis(Parenthesis::Open))
@@ -95,10 +95,10 @@ impl<Predicate> InfixExpression<Predicate> {
         while let Some(item) = operator_stack.pop() {
             match item {
                 InfixStackItem::Operator(_) => {
-                    if predicate_stack.len() < 2 {
+                    if predicate_cnt < 2 {
                         return false;
                     }
-                    predicate_stack.pop();
+                    predicate_cnt -= 1;
                 }
                 InfixStackItem::Parenthesis(_) => {
                     return false;
@@ -106,6 +106,6 @@ impl<Predicate> InfixExpression<Predicate> {
             }
         }
 
-        predicate_stack.len() == 1 && operator_stack.is_empty()
+        predicate_cnt == 1 && operator_stack.is_empty()
     }
 }

--- a/src/structs/infix_expression.rs
+++ b/src/structs/infix_expression.rs
@@ -50,7 +50,7 @@ impl<Predicate> InfixExpression<Predicate> {
             output_queue.push(PostfixToken::Operator(op));
         }
 
-        PostfixExpression::from_tokens(output_queue)
+        PostfixExpression::from_tokens_unchecked(output_queue)
     }
 
     fn are_tokens_valid(tokens: &[InfixToken<Predicate>]) -> bool {

--- a/src/structs/postfix_expression.rs
+++ b/src/structs/postfix_expression.rs
@@ -53,6 +53,22 @@ impl<Predicate> PostfixExpression<Predicate> {
     }
 
     fn are_tokens_valid(tokens: &[PostfixToken<Predicate>]) -> bool {
-        todo!("verify that the expression is valid");
+        let mut cnt: usize = 0;
+
+        for token in tokens {
+            match token {
+                PostfixToken::Operator(_) => {
+                    if cnt < 2 {
+                        return false;
+                    }
+                    cnt -= 1;
+                }
+                PostfixToken::Predicate(_) => {
+                    cnt += 1;
+                }
+            }
+        }
+
+        cnt == 1
     }
 }

--- a/src/structs/postfix_expression.rs
+++ b/src/structs/postfix_expression.rs
@@ -10,15 +10,13 @@ pub struct PostfixExpression<Predicate> {
 
 impl<Predicate> PostfixExpression<Predicate> {
     #[must_use]
-    pub fn from_tokens(tokens: Vec<PostfixToken<Predicate>>) -> Self {
-        // TODO: verify that the expression is valid
-        PostfixExpression { tokens }
+    pub fn from_tokens(tokens: Vec<PostfixToken<Predicate>>) -> Option<Self> {
+        Self::are_tokens_valid(&tokens).then(|| Self { tokens })
     }
 
     #[must_use]
     pub fn to_infix(self) -> Option<InfixExpression<Predicate>> {
-        // TODO: postfix to infix conversion
-        unimplemented!();
+        todo!("postfix to infix conversion");
     }
 
     pub fn evaluate(
@@ -50,8 +48,11 @@ impl<Predicate> PostfixExpression<Predicate> {
         Some(stack.pop()?.evaluate(evaluator))
     }
 
+    pub(crate) fn from_tokens_unchecked(tokens: Vec<PostfixToken<Predicate>>) -> Self {
+        Self { tokens }
+    }
+
     fn are_tokens_valid(tokens: &[PostfixToken<Predicate>]) -> bool {
-        // TODO: verify that the expression is valid
-        unimplemented!();
+        todo!("verify that the expression is valid");
     }
 }

--- a/src/structs/postfix_expression.rs
+++ b/src/structs/postfix_expression.rs
@@ -19,16 +19,13 @@ impl<Predicate> PostfixExpression<Predicate> {
         todo!("postfix to infix conversion");
     }
 
-    pub fn evaluate(
-        &self,
-        evaluator: &dyn PredicateEvaluator<Predicate = Predicate>,
-    ) -> Option<bool> {
+    pub fn evaluate(&self, evaluator: &dyn PredicateEvaluator<Predicate = Predicate>) -> bool {
         let mut stack: Vec<PostfixStackItem<Predicate>> = Vec::new();
         for token in &self.tokens {
             match token {
                 PostfixToken::Operator(op) => {
-                    let mut p2 = stack.pop()?;
-                    let mut p1 = stack.pop()?;
+                    let mut p2 = stack.remove(stack.len() - 1);
+                    let mut p1 = stack.remove(stack.len() - 1);
                     if matches!(p1, PostfixStackItem::Predicate(_))
                         && matches!(p2, PostfixStackItem::Result(_))
                     {
@@ -45,7 +42,7 @@ impl<Predicate> PostfixExpression<Predicate> {
                 }
             }
         }
-        Some(stack.pop()?.evaluate(evaluator))
+        stack.remove(stack.len() - 1).evaluate(evaluator)
     }
 
     pub(crate) fn from_tokens_unchecked(tokens: Vec<PostfixToken<Predicate>>) -> Self {

--- a/tests/infix.rs
+++ b/tests/infix.rs
@@ -26,6 +26,7 @@ fn test_infix_to_postfix_parenthesis() {
             PostfixToken::Operator(Operator::Or),
             PostfixToken::Operator(Operator::And),
         ])
+        .unwrap()
     );
 }
 
@@ -51,6 +52,7 @@ fn test_infix_to_postfix_plain() {
             PostfixToken::Predicate("c"),
             PostfixToken::Operator(Operator::Or),
         ])
+        .unwrap()
     );
 }
 
@@ -62,7 +64,7 @@ fn test_infix_to_postfix_single() {
     let postfix = infix.to_postfix();
     assert_eq!(
         postfix,
-        PostfixExpression::from_tokens(vec![PostfixToken::Predicate("a"),])
+        PostfixExpression::from_tokens(vec![PostfixToken::Predicate("a"),]).unwrap()
     );
 }
 
@@ -79,7 +81,7 @@ fn test_infix_to_postfix_single_with_parenthesis() {
     let postfix = infix.to_postfix();
     assert_eq!(
         postfix,
-        PostfixExpression::from_tokens(vec![PostfixToken::Predicate("a"),])
+        PostfixExpression::from_tokens(vec![PostfixToken::Predicate("a"),]).unwrap()
     );
 }
 
@@ -103,6 +105,7 @@ fn test_infix_to_postfix_simple_with_parenthesis() {
             PostfixToken::Predicate("b"),
             PostfixToken::Operator(Operator::Or),
         ])
+        .unwrap()
     );
 }
 
@@ -126,6 +129,7 @@ fn test_infix_to_postfix_simple_with_more_parenthesis() {
             PostfixToken::Predicate("b"),
             PostfixToken::Operator(Operator::Or),
         ])
+        .unwrap()
     );
 }
 
@@ -157,6 +161,7 @@ fn test_infix_to_postfix_and_or() {
                 PostfixToken::Predicate("d"),
                 PostfixToken::Operator(op),
             ])
+            .unwrap()
         );
     }
 }
@@ -219,6 +224,7 @@ fn test_infix_to_postfix_complex() {
             PostfixToken::Operator(Operator::And),
             PostfixToken::Operator(Operator::Or),
         ])
+        .unwrap()
     );
 }
 

--- a/tests/postfix.rs
+++ b/tests/postfix.rs
@@ -56,13 +56,13 @@ fn test_postfix_evaluate_single() {
 
     let expr = PostfixExpression::from_tokens(vec![PostfixToken::Predicate(a)]).unwrap();
 
-    assert!(!expr.evaluate(&MyInteger { val: 34 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 33 }).unwrap());
-    assert!(!expr.evaluate(&MyInteger { val: 12 }).unwrap());
+    assert!(!expr.evaluate(&MyInteger { val: 34 }));
+    assert!(expr.evaluate(&MyInteger { val: 33 }));
+    assert!(!expr.evaluate(&MyInteger { val: 12 }));
 
-    assert!(!expr.evaluate(&MyReal { val: 34.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 33.0 }).unwrap());
-    assert!(!expr.evaluate(&MyReal { val: 12.0 }).unwrap());
+    assert!(!expr.evaluate(&MyReal { val: 34.0 }));
+    assert!(expr.evaluate(&MyReal { val: 33.0 }));
+    assert!(!expr.evaluate(&MyReal { val: 12.0 }));
 }
 
 #[test]
@@ -84,25 +84,25 @@ fn test_postfix_evaluate_simple() {
     ])
     .unwrap();
 
-    assert!(!expr.evaluate(&MyInteger { val: 34 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 33 }).unwrap());
-    assert!(!expr.evaluate(&MyInteger { val: 12 }).unwrap());
-    assert!(!expr.evaluate(&MyInteger { val: 11 }).unwrap());
-    assert!(!expr.evaluate(&MyInteger { val: 10 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 9 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 8 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 7 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 6 }).unwrap());
+    assert!(!expr.evaluate(&MyInteger { val: 34 }));
+    assert!(expr.evaluate(&MyInteger { val: 33 }));
+    assert!(!expr.evaluate(&MyInteger { val: 12 }));
+    assert!(!expr.evaluate(&MyInteger { val: 11 }));
+    assert!(!expr.evaluate(&MyInteger { val: 10 }));
+    assert!(expr.evaluate(&MyInteger { val: 9 }));
+    assert!(expr.evaluate(&MyInteger { val: 8 }));
+    assert!(expr.evaluate(&MyInteger { val: 7 }));
+    assert!(expr.evaluate(&MyInteger { val: 6 }));
 
-    assert!(!expr.evaluate(&MyReal { val: 34.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 33.0 }).unwrap());
-    assert!(!expr.evaluate(&MyReal { val: 12.0 }).unwrap());
-    assert!(!expr.evaluate(&MyReal { val: 11.0 }).unwrap());
-    assert!(!expr.evaluate(&MyReal { val: 10.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 9.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 8.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 7.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 6.0 }).unwrap());
+    assert!(!expr.evaluate(&MyReal { val: 34.0 }));
+    assert!(expr.evaluate(&MyReal { val: 33.0 }));
+    assert!(!expr.evaluate(&MyReal { val: 12.0 }));
+    assert!(!expr.evaluate(&MyReal { val: 11.0 }));
+    assert!(!expr.evaluate(&MyReal { val: 10.0 }));
+    assert!(expr.evaluate(&MyReal { val: 9.0 }));
+    assert!(expr.evaluate(&MyReal { val: 8.0 }));
+    assert!(expr.evaluate(&MyReal { val: 7.0 }));
+    assert!(expr.evaluate(&MyReal { val: 6.0 }));
 }
 
 #[test]
@@ -154,17 +154,17 @@ fn test_postfix_evaluate_complex() {
     ])
     .unwrap();
 
-    assert!(!expr.evaluate(&MyInteger { val: 7 }).unwrap());
-    assert!(!expr.evaluate(&MyInteger { val: 6 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 5 }).unwrap());
-    assert!(!expr.evaluate(&MyInteger { val: 4 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 3 }).unwrap());
+    assert!(!expr.evaluate(&MyInteger { val: 7 }));
+    assert!(!expr.evaluate(&MyInteger { val: 6 }));
+    assert!(expr.evaluate(&MyInteger { val: 5 }));
+    assert!(!expr.evaluate(&MyInteger { val: 4 }));
+    assert!(expr.evaluate(&MyInteger { val: 3 }));
 
-    assert!(!expr.evaluate(&MyReal { val: 7.0 }).unwrap());
-    assert!(!expr.evaluate(&MyReal { val: 6.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 5.0 }).unwrap());
-    assert!(!expr.evaluate(&MyReal { val: 4.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 3.0 }).unwrap());
+    assert!(!expr.evaluate(&MyReal { val: 7.0 }));
+    assert!(!expr.evaluate(&MyReal { val: 6.0 }));
+    assert!(expr.evaluate(&MyReal { val: 5.0 }));
+    assert!(!expr.evaluate(&MyReal { val: 4.0 }));
+    assert!(expr.evaluate(&MyReal { val: 3.0 }));
 }
 
 #[test]
@@ -198,11 +198,11 @@ fn test_postfix_evaluate_many_and() {
     ])
     .unwrap();
 
-    assert!(!expr.evaluate(&MyInteger { val: 7 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 1 }).unwrap());
+    assert!(!expr.evaluate(&MyInteger { val: 7 }));
+    assert!(expr.evaluate(&MyInteger { val: 1 }));
 
-    assert!(!expr.evaluate(&MyReal { val: 7.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 1.0 }).unwrap());
+    assert!(!expr.evaluate(&MyReal { val: 7.0 }));
+    assert!(expr.evaluate(&MyReal { val: 1.0 }));
 }
 
 #[test]
@@ -236,17 +236,17 @@ fn test_postfix_evaluate_many_or() {
     ])
     .unwrap();
 
-    assert!(!expr.evaluate(&MyInteger { val: 0 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 1 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 2 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 3 }).unwrap());
-    assert!(expr.evaluate(&MyInteger { val: 4 }).unwrap());
-    assert!(!expr.evaluate(&MyInteger { val: 5 }).unwrap());
+    assert!(!expr.evaluate(&MyInteger { val: 0 }));
+    assert!(expr.evaluate(&MyInteger { val: 1 }));
+    assert!(expr.evaluate(&MyInteger { val: 2 }));
+    assert!(expr.evaluate(&MyInteger { val: 3 }));
+    assert!(expr.evaluate(&MyInteger { val: 4 }));
+    assert!(!expr.evaluate(&MyInteger { val: 5 }));
 
-    assert!(!expr.evaluate(&MyReal { val: 0.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 1.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 2.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 3.0 }).unwrap());
-    assert!(expr.evaluate(&MyReal { val: 4.0 }).unwrap());
-    assert!(!expr.evaluate(&MyReal { val: 5.0 }).unwrap());
+    assert!(!expr.evaluate(&MyReal { val: 0.0 }));
+    assert!(expr.evaluate(&MyReal { val: 1.0 }));
+    assert!(expr.evaluate(&MyReal { val: 2.0 }));
+    assert!(expr.evaluate(&MyReal { val: 3.0 }));
+    assert!(expr.evaluate(&MyReal { val: 4.0 }));
+    assert!(!expr.evaluate(&MyReal { val: 5.0 }));
 }

--- a/tests/postfix.rs
+++ b/tests/postfix.rs
@@ -250,3 +250,100 @@ fn test_postfix_evaluate_many_or() {
     assert!(expr.evaluate(&MyReal { val: 4.0 }));
     assert!(!expr.evaluate(&MyReal { val: 5.0 }));
 }
+
+#[test]
+// a+b [invalid]
+fn test_postfix_invalid_using_infix() {
+    let postfix = PostfixExpression::from_tokens(vec![
+        PostfixToken::Predicate("a"),
+        PostfixToken::Operator(Operator::Or),
+        PostfixToken::Predicate("b"),
+    ]);
+    assert!(postfix.is_none());
+}
+
+#[test]
+// *ab [invalid]
+fn test_postfix_invalid_using_prefix() {
+    let postfix = PostfixExpression::from_tokens(vec![
+        PostfixToken::Operator(Operator::And),
+        PostfixToken::Predicate("a"),
+        PostfixToken::Predicate("b"),
+    ]);
+    assert!(postfix.is_none());
+}
+
+#[test]
+// ab [invalid]
+fn test_postfix_invalid_only_predicates() {
+    let postfix = PostfixExpression::from_tokens(vec![
+        PostfixToken::Predicate("a"),
+        PostfixToken::Predicate("b"),
+    ]);
+    assert!(postfix.is_none());
+}
+
+#[test]
+// *+ [invalid]
+fn test_postfix_invalid_only_operators() {
+    let postfix = PostfixExpression::<u8>::from_tokens(vec![
+        PostfixToken::Operator(Operator::And),
+        PostfixToken::Operator(Operator::Or),
+    ]);
+    assert!(postfix.is_none());
+}
+
+#[test]
+// * [invalid]
+// + [invalid]
+fn test_postfix_invalid_single_operator() {
+    for op in vec![Operator::And, Operator::Or] {
+        let postfix = PostfixExpression::<u8>::from_tokens(vec![PostfixToken::Operator(op)]);
+        assert!(postfix.is_none());
+    }
+}
+
+#[test]
+// a*+ [invalid]
+fn test_postfix_invalid_too_many_operators() {
+    let postfix = PostfixExpression::from_tokens(vec![
+        PostfixToken::Predicate("a"),
+        PostfixToken::Operator(Operator::And),
+        PostfixToken::Operator(Operator::Or),
+    ]);
+    assert!(postfix.is_none());
+}
+
+#[test]
+// a* [invalid]
+fn test_postfix_invalid_missing_a_predicate() {
+    let postfix = PostfixExpression::from_tokens(vec![
+        PostfixToken::Predicate("a"),
+        PostfixToken::Operator(Operator::And),
+    ]);
+    assert!(postfix.is_none());
+}
+
+#[test]
+// abc+ [invalid]
+fn test_postfix_invalid_too_many_predicates() {
+    let postfix = PostfixExpression::from_tokens(vec![
+        PostfixToken::Predicate("a"),
+        PostfixToken::Predicate("b"),
+        PostfixToken::Predicate("c"),
+        PostfixToken::Operator(Operator::Or),
+    ]);
+    assert!(postfix.is_none());
+}
+
+#[test]
+// ab*c [invalid]
+fn test_postfix_invalid_too_many_predicates_bis() {
+    let postfix = PostfixExpression::from_tokens(vec![
+        PostfixToken::Predicate("a"),
+        PostfixToken::Predicate("b"),
+        PostfixToken::Operator(Operator::And),
+        PostfixToken::Predicate("c"),
+    ]);
+    assert!(postfix.is_none());
+}

--- a/tests/postfix.rs
+++ b/tests/postfix.rs
@@ -54,7 +54,7 @@ fn test_postfix_evaluate_single() {
         val: "33".to_string(),
     };
 
-    let expr = PostfixExpression::from_tokens(vec![PostfixToken::Predicate(a)]);
+    let expr = PostfixExpression::from_tokens(vec![PostfixToken::Predicate(a)]).unwrap();
 
     assert!(!expr.evaluate(&MyInteger { val: 34 }).unwrap());
     assert!(expr.evaluate(&MyInteger { val: 33 }).unwrap());
@@ -81,7 +81,8 @@ fn test_postfix_evaluate_simple() {
         PostfixToken::Predicate(a),
         PostfixToken::Predicate(b),
         PostfixToken::Operator(Operator::Or),
-    ]);
+    ])
+    .unwrap();
 
     assert!(!expr.evaluate(&MyInteger { val: 34 }).unwrap());
     assert!(expr.evaluate(&MyInteger { val: 33 }).unwrap());
@@ -150,7 +151,8 @@ fn test_postfix_evaluate_complex() {
         PostfixToken::Operator(Operator::Or),
         PostfixToken::Operator(Operator::And),
         PostfixToken::Operator(Operator::Or),
-    ]);
+    ])
+    .unwrap();
 
     assert!(!expr.evaluate(&MyInteger { val: 7 }).unwrap());
     assert!(!expr.evaluate(&MyInteger { val: 6 }).unwrap());
@@ -193,7 +195,8 @@ fn test_postfix_evaluate_many_and() {
         PostfixToken::Operator(Operator::And),
         PostfixToken::Predicate(d),
         PostfixToken::Operator(Operator::And),
-    ]);
+    ])
+    .unwrap();
 
     assert!(!expr.evaluate(&MyInteger { val: 7 }).unwrap());
     assert!(expr.evaluate(&MyInteger { val: 1 }).unwrap());
@@ -230,7 +233,8 @@ fn test_postfix_evaluate_many_or() {
         PostfixToken::Operator(Operator::Or),
         PostfixToken::Predicate(d),
         PostfixToken::Operator(Operator::Or),
-    ]);
+    ])
+    .unwrap();
 
     assert!(!expr.evaluate(&MyInteger { val: 0 }).unwrap());
     assert!(expr.evaluate(&MyInteger { val: 1 }).unwrap());


### PR DESCRIPTION
Ensure that objects of type `PostfixExpression` are always valid.