### PR TITLE
Postfix to infix conversion

### DIFF
--- a/src/enums/infix_token.rs
+++ b/src/enums/infix_token.rs
@@ -1,6 +1,7 @@
 use crate::enums::operator::Operator;
 use crate::Parenthesis;
 
+#[derive(Debug, PartialEq)]
 pub enum InfixToken<Predicate> {
     Parenthesis(Parenthesis),
     Operator(Operator),

--- a/src/enums/parenthesis.rs
+++ b/src/enums/parenthesis.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Parenthesis {
     Open,
     Close,

--- a/src/structs/infix_expression.rs
+++ b/src/structs/infix_expression.rs
@@ -1,6 +1,7 @@
 use crate::internals::infix_stack_item::InfixStackItem;
 use crate::{InfixToken, Parenthesis, PostfixExpression, PostfixToken};
 
+#[derive(Debug, PartialEq)]
 pub struct InfixExpression<Predicate> {
     tokens: Vec<InfixToken<Predicate>>,
 }
@@ -51,6 +52,10 @@ impl<Predicate> InfixExpression<Predicate> {
         }
 
         PostfixExpression::from_tokens_unchecked(output_queue)
+    }
+
+    pub(crate) fn from_tokens_unchecked(tokens: Vec<InfixToken<Predicate>>) -> Self {
+        Self { tokens }
     }
 
     fn are_tokens_valid(tokens: &[InfixToken<Predicate>]) -> bool {

--- a/src/structs/postfix_expression.rs
+++ b/src/structs/postfix_expression.rs
@@ -31,17 +31,12 @@ impl<Predicate> PostfixExpression<Predicate> {
                     let op2 = operator_stack.remove(operator_stack.len() - 1);
                     let op1 = operator_stack.remove(operator_stack.len() - 1);
 
-                    if let Some(op1) = op1 {
-                        if op1.precedence() < op.precedence() {
-                            p1.insert(0, InfixToken::Parenthesis(Parenthesis::Open));
-                            p1.push(InfixToken::Parenthesis(Parenthesis::Close));
-                        }
-                    }
-
-                    if let Some(op2) = op2 {
-                        if op2.precedence() < op.precedence() {
-                            p2.insert(0, InfixToken::Parenthesis(Parenthesis::Open));
-                            p2.push(InfixToken::Parenthesis(Parenthesis::Close));
+                    for (operator, p) in [(op1, &mut p1), (op2, &mut p2)] {
+                        if let Some(operator) = operator {
+                            if operator.precedence() < op.precedence() {
+                                p.insert(0, InfixToken::Parenthesis(Parenthesis::Open));
+                                p.push(InfixToken::Parenthesis(Parenthesis::Close));
+                            }
                         }
                     }
 


### PR DESCRIPTION
Implemented algorithm to convert an expression with generic predicates from postfix to infix (Shunting Yard reverse).